### PR TITLE
feature/private networking

### DIFF
--- a/cmd/nodepool/up.go
+++ b/cmd/nodepool/up.go
@@ -42,7 +42,7 @@ func runCmdUp(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Failed to validate user data: %v", err)
 	}
 
-	data, err := conf.RenderStackTemplate(stackTemplateOptions(), upOpts.export)
+	data, err := conf.RenderStackTemplate(stackTemplateOptions(), upOpts.prettyPrint)
 	if err != nil {
 		return fmt.Errorf("Failed to render stack template: %v", err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -249,6 +249,7 @@ type WorkerSettings struct {
 	WorkerSpotPrice        string   `yaml:"workerSpotPrice,omitempty"`
 	WorkerSecurityGroupIds []string `yaml:"workerSecurityGroupIds,omitempty"`
 	WorkerTenancy          string   `yaml:"workerTenancy,omitempty"`
+	WorkerTopologyPrivate  bool     `yaml:"workerTopologyPrivate,omitempty"`
 }
 
 // Part of configuration which is specific to controller nodes
@@ -986,12 +987,16 @@ func (c *Cluster) AvailabilityZones() []string {
 		return []string{c.AvailabilityZone}
 	}
 
-	azs := make([]string, len(c.Subnets))
-	for i := range azs {
-		azs[i] = c.Subnets[i].AvailabilityZone
+	result := []string{}
+	seen := map[string]bool{}
+	for _, s := range c.Subnets{
+		val := s.AvailabilityZone
+		if _, ok := seen[val]; !ok {
+			result = append(result, val)
+			seen[val] = true
+		}
 	}
-
-	return azs
+	return result
 }
 
 /*

--- a/config/templates/cluster.yaml
+++ b/config/templates/cluster.yaml
@@ -89,11 +89,9 @@ kmsKeyArn: "{{.KMSKeyARN}}"
 #    minSize: 1
 #    maxSize: 3
 #    rollingUpdateMinInstancesInService: 2
-#  privateSubnets:
-#    - availabilityZone: us-west-1a
-#      instanceCIDR: "10.0.6.0/24"
-#    - availabilityZone: us-west-1b
-#      instanceCIDR: "10.0.7.0/24"
+
+# Setting worker topology private ensures NAT Gateways are created for use in node pools.
+#workerTopologyPrivate: true
 
 # Maximum time to wait for worker creation
 #workerCreateTimeout: PT15M

--- a/config/templates/stack-template.json
+++ b/config/templates/stack-template.json
@@ -44,10 +44,10 @@
         ],
         {{if .Experimental.LoadBalancer.Enabled}}
         "LoadBalancerNames" : [
-        {{range $index, $elb := .Experimental.LoadBalancer.Names}}
-        {{if $index}},{{end}}
+          {{range $index, $elb := .Experimental.LoadBalancer.Names}}
+          {{if $index}},{{end}}
           "{{$elb}}"
-        {{end}}
+          {{end}}
         ],
         {{end}}
         "VPCZoneIdentifier": [
@@ -177,11 +177,11 @@
     "ExternalDNS": {
       "Type": "AWS::Route53::RecordSet",
       "Properties": {
-	{{ if .HostedZoneID }}
+        {{if .HostedZoneID}}
         "HostedZoneId": "{{.HostedZoneID}}",
-	{{else}}
+	    {{else}}
         "HostedZoneName": "{{.HostedZone}}",
-	{{ end }}
+	    {{end}}
         "Name": "{{.ExternalDNSName}}",
         "TTL": {{.RecordSetTTL}},
         "ResourceRecords": [{ "Fn::GetAtt": ["ElbAPIServer", "DNSName"]}],
@@ -614,9 +614,18 @@
           "UnhealthyThreshold" : "3"
         },
         "Subnets" : [
+          {{if .Controller.TopologyPrivate}}
+          {{range $index, $controllerSubnet := .Controller.PrivateSubnets}}
+          {{with $controllerSubnetLogicalName := printf "Controller%s" $controllerSubnet.LogicalName}}
+          {{if gt $index 0}},{{end}}
+          {"Ref": "{{$controllerSubnetLogicalName}}"}
+          {{end}}
+          {{end}}
+          {{else}}
           {{range $index, $subnet := .Subnets}}
           {{if gt $index 0}},{{end}}
           { "Ref" : "{{$subnet.LogicalName}}" }
+          {{end}}
           {{end}}
         ],
         "Listeners" : [
@@ -627,7 +636,9 @@
             "Protocol" : "TCP"
           }
         ],
-        {{if .MapPublicIPs}}
+        {{if .Controller.TopologyPrivate}}
+        "Scheme": "internal",
+        {{else if .MapPublicIPs}}
         "Scheme": "internet-facing",
         {{else}}
         "Scheme": "internal",
@@ -1018,6 +1029,7 @@
       },
       "Type": "AWS::EC2::SecurityGroup"
     }
+    {{/* TODO: Add Worker Mount Target */}}
     {{range $index, $subnet := .Subnets}}
     ,
     "{{$subnet.LogicalName}}MountTarget": {
@@ -1051,40 +1063,12 @@
         "VpcId": {{$.VPCRef}}
       },
       "Type": "AWS::EC2::Subnet"
-    }
-    {{if not $subnet.RouteTableID}}
-    ,
-    "{{$subnet.LogicalName}}RouteTable": {
-      "Properties": {
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": "{{$.ClusterName}}-{{$subnet.LogicalName}}-route-table"
-          },
-          {
-            "Key": "KubernetesCluster",
-            "Value": "{{$.ClusterName}}"
-          }
-        ],
-        "VpcId": {{$.VPCRef}}
-      },
-      "Type": "AWS::EC2::RouteTable"
     },
-    "{{$subnet.LogicalName}}RouteToInternet": {
-      "Properties": {
-        "DestinationCidrBlock": "0.0.0.0/0",
-        "GatewayId": {{$.InternetGatewayRef}},
-        "RouteTableId": {"Ref" : "{{$subnet.LogicalName}}RouteTable"}
-      },
-      "Type": "AWS::EC2::Route"
-    }
-    {{end}}
-    ,
     "{{$subnet.LogicalName}}RouteTableAssociation": {
       "Properties": {
         "RouteTableId":
           {{if not $subnet.RouteTableID}}
-          {"Ref" : "{{$subnet.LogicalName}}RouteTable"},
+          {"Ref" : "PublicRouteTable"},
           {{else}}
           "{{$subnet.RouteTableID}}",
           {{end}}
@@ -1119,44 +1103,12 @@
       },
       "Type": "AWS::EC2::Subnet"
     }
-    {{if not $subnet.RouteTableID}}
-    ,
-    "{{$etcdSubnetLogicalName}}RouteTable": {
-      "Properties": {
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": "{{$.ClusterName}}-{{$etcdSubnetLogicalName}}-route-table"
-          },
-          {
-            "Key": "KubernetesCluster",
-            "Value": "{{$.ClusterName}}"
-          }
-        ],
-        "VpcId": {{$.VPCRef}}
-      },
-      "Type": "AWS::EC2::RouteTable"
-    },
-    "{{$etcdSubnetLogicalName}}RouteToNatGateway": {
-      "Properties": {
-        "DestinationCidrBlock": "0.0.0.0/0",
-        "NatGatewayId":
-          {{if not $subnet.NatGateway.ID}}
-          {"Ref": "{{$subnet.LogicalName}}NatGateway"},
-          {{else}}
-          "{{$subnet.NatGateway.ID}}",
-          {{end}}
-        "RouteTableId": {"Ref" : "{{$etcdSubnetLogicalName}}RouteTable"}
-      },
-      "Type": "AWS::EC2::Route"
-    }
-    {{end}}
     ,
     "{{$etcdSubnetLogicalName}}RouteTableAssociation": {
       "Properties": {
         "RouteTableId":
           {{if not $subnet.RouteTableID}}
-          {"Ref" : "{{$etcdSubnetLogicalName}}RouteTable"},
+          {"Ref" : "PrivateRouteTable{{$subnet.AvailabilityZoneLogicalName}}"},
           {{else}}
           "{{$subnet.RouteTableID}}",
           {{end}}
@@ -1193,43 +1145,12 @@
       },
       "Type": "AWS::EC2::Subnet"
     }
-    {{if not $subnet.RouteTableID}}
-    "{{$controllerSubnetLogicalName}}RouteTable": {
-      "Properties": {
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": "{{$.ClusterName}}-{{$controllerSubnetLogicalName}}-route-table"
-          },
-          {
-            "Key": "KubernetesCluster",
-            "Value": "{{$.ClusterName}}"
-          }
-        ],
-        "VpcId": {{$.VPCRef}}
-      },
-      "Type": "AWS::EC2::RouteTable"
-    },
-    "{{$controllerSubnetLogicalName}}RouteToNatGateway": {
-      "Properties": {
-        "DestinationCidrBlock": "0.0.0.0/0",
-        "NatGatewayId":
-          {{if not $subnet.NatGateway.ID}}
-          {"Ref": "{{$subnet.LogicalName}}NatGateway"},
-          {{else}}
-          "{{$subnet.NatGateway.ID}}",
-          {{end}}
-        "RouteTableId": {"Ref" : "{{$controllerSubnetLogicalName}}RouteTable"}
-      },
-      "Type": "AWS::EC2::Route"
-    }
-    {{end}}
     ,
     "{{$controllerSubnetLogicalName}}RouteTableAssociation": {
       "Properties": {
         "RouteTableId":
           {{if not $subnet.RouteTableID}}
-          {"Ref" : "{{$controllerSubnetLogicalName}}RouteTable"},
+          {"Ref" : "PrivateRouteTable{{$subnet.AvailabilityZoneLogicalName}}"},
           {{else}}
           "{{$subnet.RouteTableID}}",
           {{end}}
@@ -1243,37 +1164,13 @@
     {{end}}
     {{end}}
 
-    {{if $.Worker.TopologyPrivate}}
-    {{range $index, $subnet := .Worker.PrivateSubnets}}
-    {{with $workerSubnetLogicalName := printf "Worker%s" $subnet.LogicalName}}
     ,
-    "{{$workerSubnetLogicalName}}": {
-      "Properties": {
-        "AvailabilityZone": "{{$subnet.AvailabilityZone}}",
-        "CidrBlock": "{{$subnet.InstanceCIDR}}",
-        "MapPublicIpOnLaunch": {{not $.Worker.TopologyPrivate}},
-        "Tags": [
-          {
-            "Key": "Name",
-            "Value": "{{$.ClusterName}}-{{$workerSubnetLogicalName}}"
-          },
-          {
-            "Key": "KubernetesCluster",
-            "Value": "{{$.ClusterName}}"
-          }
-        ],
-        "VpcId": {{$.VPCRef}}
-      },
-      "Type": "AWS::EC2::Subnet"
-    }
-    {{if not $subnet.RouteTableID}}
-    ,
-    "{{$workerSubnetLogicalName}}RouteTable": {
+    "PublicRouteTable": {
       "Properties": {
         "Tags": [
           {
             "Key": "Name",
-            "Value": "{{$.ClusterName}}-{{$workerSubnetLogicalName}}-route-table"
+            "Value": "{{$.ClusterName}}-PublicRouteTable"
           },
           {
             "Key": "KubernetesCluster",
@@ -1284,44 +1181,20 @@
       },
       "Type": "AWS::EC2::RouteTable"
     },
-    "{{$workerSubnetLogicalName}}RouteToNatGateway": {
+    "PublicRouteToInternet": {
       "Properties": {
         "DestinationCidrBlock": "0.0.0.0/0",
-        "NatGatewayId":
-          {{if not $subnet.NatGateway.ID}}
-          {"Ref": "{{$subnet.LogicalName}}NatGateway"},
-          {{else}}
-          "{{$subnet.NatGateway.ID}}",
-          {{end}}
-        "RouteTableId": {"Ref" : "{{$workerSubnetLogicalName}}RouteTable"}
+        "GatewayId": {{$.InternetGatewayRef}},
+        "RouteTableId": {"Ref" : "PublicRouteTable"}
       },
       "Type": "AWS::EC2::Route"
     }
-    {{end}}
-    ,
-    "{{$workerSubnetLogicalName}}RouteTableAssociation": {
-      "Properties": {
-        "RouteTableId":
-          {{if not $subnet.RouteTableID}}
-          {"Ref" : "{{$workerSubnetLogicalName}}RouteTable"},
-          {{else}}
-          "{{$subnet.RouteTableID}}",
-          {{end}}
-        "SubnetId": {
-          "Ref": "{{$workerSubnetLogicalName}}"
-        }
-      },
-      "Type": "AWS::EC2::SubnetRouteTableAssociation"
-    }
-    {{end}}
-    {{end}}
-    {{end}}
 
-    {{if (or .Worker.TopologyPrivate .Etcd.TopologyPrivate .Controller.TopologyPrivate)}}
+    {{if (or .WorkerTopologyPrivate .Etcd.TopologyPrivate .Controller.TopologyPrivate)}}
     {{range $index, $subnet := .Subnets}}
     {{if not $subnet.NatGateway.EIPAllocationID}}
     ,
-    "{{$subnet.LogicalName}}EIPNatGateway": {
+    "NatGateway{{$subnet.AvailabilityZoneLogicalName}}EIP": {
       "Properties": {
         "Domain": "vpc"
       },
@@ -1330,11 +1203,11 @@
     {{end}}
     {{if not $subnet.NatGateway.ID}}
     ,
-    "{{$subnet.LogicalName}}NatGateway": {
+    "NatGateway{{$subnet.AvailabilityZoneLogicalName}}": {
       "Properties": {
         "AllocationId":
           {{if not $subnet.NatGateway.EIPAllocationID}}
-          {"Fn::GetAtt": ["{{$subnet.LogicalName}}EIPNatGateway", "AllocationId"]},
+          {"Fn::GetAtt": ["NatGateway{{$subnet.AvailabilityZoneLogicalName}}EIP", "AllocationId"]},
           {{else}}
           "{{$subnet.NatGateway.EIPAllocationID}}",
           {{end}}
@@ -1343,6 +1216,36 @@
       "Type": "AWS::EC2::NatGateway"
     }
     {{end}}
+    ,
+    "PrivateRouteTable{{$subnet.AvailabilityZoneLogicalName}}": {
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "{{$.ClusterName}}-PrivateRouteTable{{$subnet.AvailabilityZoneLogicalName}}"
+          },
+          {
+            "Key": "KubernetesCluster",
+            "Value": "{{$.ClusterName}}"
+          }
+        ],
+        "VpcId": {{$.VPCRef}}
+      },
+      "Type": "AWS::EC2::RouteTable"
+    },
+    "PrivateRouteTable{{$subnet.AvailabilityZoneLogicalName}}RouteToNatGateway": {
+      "Properties": {
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "NatGatewayId":
+          {{if not $subnet.NatGateway.ID}}
+          {"Ref": "NatGateway{{$subnet.AvailabilityZoneLogicalName}}"},
+          {{else}}
+          "{{$subnet.NatGateway.ID}}",
+          {{end}}
+        "RouteTableId": {"Ref" : "PrivateRouteTable{{$subnet.AvailabilityZoneLogicalName}}"}
+      },
+      "Type": "AWS::EC2::Route"
+    }
     {{end}}
     {{end}}
 
@@ -1353,7 +1256,7 @@
         "Tags": [
           {
             "Key": "Name",
-            "Value": "{{$.ClusterName}}-igw"
+            "Value": "{{$.ClusterName}}-{{.InternetGatewayLogicalName}}"
           },
           {
             "Key": "KubernetesCluster",
@@ -1406,19 +1309,17 @@
       "Export" : { "Name" : {"Fn::Sub": "${AWS::StackName}-VPC" }}
     },
     {{end}}
-    {{range $index, $subnet := .Subnets}}
-    "{{$subnet.LogicalName}}" : {
-      "Description" : "The public subnets assigned to worker nodes",
-      "Value" :  { "Ref" : "{{$subnet.LogicalName}}" },
-      "Export" : { "Name" : {"Fn::Sub": "${AWS::StackName}-{{$subnet.LogicalName}}" }}
+    "PublicRouteTable" : {
+      "Description" : "The public route table assigned to the internet gateway for worker nodes",
+      "Value" :  { "Ref" : "PublicRouteTable" },
+      "Export" : { "Name" : {"Fn::Sub": "${AWS::StackName}-PublicRouteTable" }}
     },
-    {{end}}
-    {{if (or .Worker.TopologyPrivate)}}
-    {{range $index, $subnet := .Worker.PrivateSubnets}}
-    "{{$subnet.LogicalName}}" : {
-      "Description" : "The private subnets assigned to worker nodes",
-      "Value" :  { "Ref" : "{{$subnet.LogicalName}}" },
-      "Export" : { "Name" : {"Fn::Sub": "${AWS::StackName}-{{$subnet.LogicalName}}" }}
+    {{if .WorkerTopologyPrivate}}
+    {{range $index, $subnet := .Subnets}}
+    "PrivateRouteTable{{$subnet.AvailabilityZoneLogicalName}}" : {
+      "Description" : "The private route table assigned to the nat gateway for worker nodes",
+      "Value" :  { "Ref" : "PrivateRouteTable{{$subnet.AvailabilityZoneLogicalName}}" },
+      "Export" : { "Name" : {"Fn::Sub": "${AWS::StackName}-PrivateRouteTable{{$subnet.AvailabilityZoneLogicalName}}" }}
     },
     {{end}}
     {{end}}

--- a/model/subnet.go
+++ b/model/subnet.go
@@ -1,6 +1,8 @@
 package model
 
-import "strings"
+import (
+	"strings"
+)
 
 type Subneter interface {
 	LogicalName() string
@@ -14,8 +16,12 @@ type Subnet struct {
 	NatGateway        NatGateway `yaml:"natGateway,omitempty"`
 }
 
+func (c Subnet) AvailabilityZoneLogicalName() string {
+	return strings.Replace(strings.Title(c.AvailabilityZone), "-", "", -1)
+}
+
 func (c Subnet) LogicalName() string {
-	return "Subnet" + strings.Replace(strings.Title(c.AvailabilityZone), "-", "", -1)
+	return "Subnet" + c.AvailabilityZoneLogicalName()
 }
 
 type PrivateSubnet struct {
@@ -23,7 +29,7 @@ type PrivateSubnet struct {
 }
 
 func (c PrivateSubnet) LogicalName() string {
-	return "PrivateSubnet" + strings.Replace(strings.Title(c.AvailabilityZone), "-", "", -1)
+	return "Private" + c.Subnet.LogicalName()
 }
 
 type NatGateway struct {

--- a/nodepool/config/config.go
+++ b/nodepool/config/config.go
@@ -225,13 +225,6 @@ func (c ComputedConfig) VPCRef() string {
 	return fmt.Sprintf(`{"Fn::ImportValue" : {"Fn::Sub" : "%s-VPC"}}`, c.ClusterName)
 }
 
-func (c ComputedConfig) RouteTableRef() string {
-	if c.RouteTableID != "" {
-		return fmt.Sprintf("%q", c.RouteTableID)
-	}
-	return fmt.Sprintf(`{"Fn::ImportValue" : {"Fn::Sub" : "%s-RouteTable"}}`, c.ClusterName)
-}
-
 func (c ComputedConfig) WorkerSecurityGroupRefs() []string {
 	refs := c.WorkerDeploymentSettings().WorkerSecurityGroupRefs()
 

--- a/nodepool/config/templates/stack-template.json
+++ b/nodepool/config/templates/stack-template.json
@@ -8,8 +8,8 @@
         "TargetCapacity": {{$.Worker.SpotFleet.TargetCapacity}},
         "SpotPrice": "{{$.Worker.SpotFleet.SpotPrice}}",
         "LaunchSpecifications": [
-          {{range $subnetIndex, $subnet := $.Subnets}}
-          {{with $subnetLogicalName := printf "Subnet%d" $subnetIndex}}
+          {{if .Worker.TopologyPrivate}}
+          {{range $subnetIndex, $subnet := $.Worker.PrivateSubnets}}
           {{range $specIndex, $spec := $.Worker.SpotFleet.LaunchSpecifications}}
           {{if or (gt $subnetIndex 0) (gt $specIndex 0) }},{{end}}
           {
@@ -44,7 +44,49 @@
               {{end}}
             ],
             "SubnetId": {
-              "Ref": "{{$subnetLogicalName}}"
+              "Ref": "{{$subnet.LogicalName}}"
+            },
+            "UserData": "{{$.UserDataWorker}}"
+          }
+          {{end}}
+          {{end}}
+          {{else}}
+          {{range $subnetIndex, $subnet := $.Subnets}}
+          {{range $specIndex, $spec := $.Worker.SpotFleet.LaunchSpecifications}}
+          {{if or (gt $subnetIndex 0) (gt $specIndex 0) }},{{end}}
+          {
+            "ImageId": "{{$.AMI}}",
+            "InstanceType": "{{$spec.InstanceType}}",
+            "KeyName": "{{$.KeyName}}",
+            "WeightedCapacity": {{$spec.WeightedCapacity}},
+            {{if $spec.SpotPrice}}
+            "SpotPrice": "{{$spec.SpotPrice}}",
+            {{end}}
+            "IamInstanceProfile": {
+              "Arn": {
+                "Fn::GetAtt" : ["IAMInstanceProfileWorker", "Arn"]
+              }
+            },
+            "BlockDeviceMappings": [
+              {
+                "DeviceName": "/dev/xvda",
+                "Ebs": {
+                  "VolumeSize": "{{$spec.RootVolumeSize}}",
+                  {{if gt $spec.RootVolumeIOPS 0}}
+                  "Iops": "{{$spec.RootVolumeIOPS}}",
+                  {{end}}
+                  "VolumeType": "{{$spec.RootVolumeType}}"
+                }
+              }
+            ],
+            "SecurityGroups": [
+              {{range $sgIndex, $sgRef := $.WorkerSecurityGroupRefs}}
+              {{if gt $sgIndex 0}},{{end}}
+              {"GroupId":{{$sgRef}}}
+              {{end}}
+            ],
+            "SubnetId": {
+              "Ref": "{{$subnet.LogicalName}}"
             },
             "UserData": "{{$.UserDataWorker}}"
           }
@@ -60,9 +102,16 @@
     "AutoScaleWorker": {
       "Properties": {
         "AvailabilityZones": [
+          {{if .Worker.TopologyPrivate}}
+          {{range $index, $subnet := .Worker.PrivateSubnets}}
+          {{if gt $index 0}},{{end}}
+          "{{$subnet.AvailabilityZone}}"
+          {{end}}
+          {{else}}
           {{range $index, $subnet := .Subnets}}
           {{if gt $index 0}},{{end}}
           "{{$subnet.AvailabilityZone}}"
+          {{end}}
           {{end}}
         ],
         "HealthCheckGracePeriod": 600,
@@ -103,11 +152,18 @@
         ],
         {{end}}
         "VPCZoneIdentifier": [
-          {{range $index, $subnet := .Subnets}}
-          {{with $subnetLogicalName := printf "Subnet%d" $index}}
+          {{if .Worker.TopologyPrivate}}
+          {{range $index, $subnet := .Worker.PrivateSubnets}}
           {{if gt $index 0}},{{end}}
           {
-            "Ref": "{{$subnetLogicalName}}"
+            "Ref": "{{$subnet.LogicalName}}"
+          }
+          {{end}}
+          {{else}}
+          {{range $index, $subnet := .Subnets}}
+          {{if gt $index 0}},{{end}}
+          {
+            "Ref": "{{$subnet.LogicalName}}"
           }
           {{end}}
           {{end}}
@@ -197,7 +253,7 @@
 {{end}}
 {
   "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "kube-aws Kubernetes node pool {{.NodePoolName}}",
+  "Description": "kube-aws Kubernetes node pool {{.ClusterName}} {{.NodePoolName}}",
   "Resources": {
     {{if .Worker.SpotFleet.Enabled}}
     {{template "SpotFleet" .}}
@@ -317,18 +373,47 @@
       },
       "Type": "AWS::IAM::Role"
     }
-    {{range $index, $subnet := .Subnets}}
-    {{with $subnetLogicalName := printf "Subnet%d" $index}}
+
+    {{if $.ElasticFileSystemID}}
+    {{if $.Worker.TopologyPrivate}}
+    {{range $index, $subnet := .Worker.PrivateSubnets}}
     ,
-    "{{$subnetLogicalName}}": {
+    "{{$subnet.LogicalName}}MountTarget": {
+      "Properties" : {
+        "FileSystemId": "{{$.ElasticFileSystemID}}",
+        "SubnetId": { "Ref": "{{$subnet.LogicalName}}" },
+        "SecurityGroups": [ { "Ref": "SecurityGroupMountTarget" } ]
+      },
+      "Type" : "AWS::EFS::MountTarget"
+    }
+    {{end}}
+    {{else}}
+    {{range $index, $subnet := .Subnets}}
+    ,
+    "{{$subnet.LogicalName}}MountTarget": {
+      "Properties" : {
+        "FileSystemId": "{{$.ElasticFileSystemID}}",
+        "SubnetId": { "Ref": "{{$subnet.LogicalName}}" },
+        "SecurityGroups": [ { "Ref": "SecurityGroupMountTarget" } ]
+      },
+      "Type" : "AWS::EFS::MountTarget"
+    }
+    {{end}}
+    {{end}}
+    {{end}}
+
+    {{if $.Worker.TopologyPrivate}}
+    {{range $index, $subnet := .Worker.PrivateSubnets}}
+    ,
+    "{{$subnet.LogicalName}}": {
       "Properties": {
         "AvailabilityZone": "{{$subnet.AvailabilityZone}}",
         "CidrBlock": "{{$subnet.InstanceCIDR}}",
-        "MapPublicIpOnLaunch": {{$.MapPublicIPs}},
+        "MapPublicIpOnLaunch": {{not $.Worker.TopologyPrivate}},
         "Tags": [
           {
             "Key": "Name",
-            "Value": "{{$.NodePoolName}}-{{$subnetLogicalName}}"
+            "Value": "{{$.ClusterName}}-{{$.NodePoolName}}-{{$subnet.LogicalName}}"
           },
           {
             "Key": "KubernetesCluster",
@@ -338,33 +423,34 @@
         "VpcId": {{$.VPCRef}}
       },
       "Type": "AWS::EC2::Subnet"
-    }
-    {{if $.ElasticFileSystemID}}
-    ,
-    "{{$subnetLogicalName}}MountTarget": {
-      "Properties" : {
-        "FileSystemId": "{{$.ElasticFileSystemID}}",
-        "SubnetId": { "Ref": "{{$subnetLogicalName}}" },
-        "SecurityGroups": [ { "Ref": "SecurityGroupMountTarget" } ]
-      },
-      "Type" : "AWS::EFS::MountTarget"
-    }
-    {{end}}
-    {{end}}
-    {{end}}
-
-    {{/*TODO: Add worker subnet specific logic */}}
-    {{if $.Worker.TopologyPrivate}}
-    {{range $index, $subnet := .Subnets}}
-    {{with $workerSubnetLogicalName := printf "Worker%s" $subnet.LogicalName}}
-    {{if not $subnet.RouteTableID}}
-    ,
-    "{{$workerSubnetLogicalName}}RouteTable": {
+    },
+    "{{$subnet.LogicalName}}RouteTableAssociation": {
       "Properties": {
+        "RouteTableId":
+          {{if not $subnet.RouteTableID}}
+          {"Fn::ImportValue" : {"Fn::Sub" : "{{$.ClusterName}}-PrivateRouteTable{{$subnet.AvailabilityZoneLogicalName}}"}},
+          {{else}}
+          "{{$subnet.RouteTableID}}",
+          {{end}}
+        "SubnetId": {
+          "Ref": "{{$subnet.LogicalName}}"
+        }
+      },
+      "Type": "AWS::EC2::SubnetRouteTableAssociation"
+    }
+    {{end}}
+    {{else}}
+    {{range $index, $subnet := .Subnets}}
+    ,
+    "{{$subnet.LogicalName}}": {
+      "Properties": {
+        "AvailabilityZone": "{{$subnet.AvailabilityZone}}",
+        "CidrBlock": "{{$subnet.InstanceCIDR}}",
+        "MapPublicIpOnLaunch": {{$.MapPublicIPs}},
         "Tags": [
           {
             "Key": "Name",
-            "Value": "{{$.ClusterName}}-{{$workerSubnetLogicalName}}-route-table"
+            "Value": "{{$.ClusterName}}-{{$.NodePoolName}}-{{$subnet.LogicalName}}"
           },
           {
             "Key": "KubernetesCluster",
@@ -373,61 +459,23 @@
         ],
         "VpcId": {{$.VPCRef}}
       },
-      "Type": "AWS::EC2::RouteTable"
-    }
-    {{end}}
-    ,
-    {{if not $subnet.NatGateway.ID && not $subnet.RouteTableID}}
-    "{{$workerSubnetLogicalName}}RouteToNatGateway": {
-      "Properties": {
-        "DestinationCidrBlock": "0.0.0.0/0",
-        "NatGatewayId":
-          {{if not $subnet.NatGateway.ID}}
-          {"Ref": "{{$subnet.LogicalName}}NatGateway"},
-          {{else}}
-          "{{$subnet.NatGateway.ID}}",
-          {{end}}
-        "RouteTableId":
-          {{if not $subnet.RouteTableID}}
-          {"Ref" : "{{$workerSubnetLogicalName}}RouteTable"}
-          {{else}}
-          "{{$subnet.RouteTableID}}"
-          {{end}}
-      },
-      "Type": "AWS::EC2::Route"
+      "Type": "AWS::EC2::Subnet"
     },
-    {{end}}
-    "{{$workerSubnetLogicalName}}RouteTableAssociation": {
+    "{{$subnet.LogicalName}}RouteTableAssociation": {
       "Properties": {
         "RouteTableId":
-          {{if not $subnet.RouteTableID}}
-          {"Ref" : "{{$workerSubnetLogicalName}}RouteTable"},
+          {{if not $.RouteTableID}}
+          {"Fn::ImportValue" : {"Fn::Sub" : "{{$.ClusterName}}-PublicRouteTable"}},
           {{else}}
-          "{{$subnet.RouteTableID}}",
+          "{{$.RouteTableID}}",
           {{end}}
         "SubnetId": {
-          "Ref": "{{$workerSubnetLogicalName}}"
+          "Ref": "{{$subnet.LogicalName}}"
         }
       },
       "Type": "AWS::EC2::SubnetRouteTableAssociation"
     }
     {{end}}
     {{end}}
-
-    {{range $index, $subnet := .Subnets}}
-    {{with $subnetLogicalName := printf "Subnet%d" $index}}
-    ,
-    "{{$subnetLogicalName}}RouteTableAssociation": {
-      "Properties": {
-        "RouteTableId": {{$.RouteTableRef}},
-        "SubnetId": {
-          "Ref": "{{$subnetLogicalName}}"
-        }
-      },
-      "Type": "AWS::EC2::SubnetRouteTableAssociation"
-    }
-    {{end}}
-    {{end}}
-
   }
 }


### PR DESCRIPTION
Hey! hope this doesn't step on any toes as I know you had stated you were working on this, but I had some free time and was very interested in getting the private networking working for (and learning) kube-aws.

Code is brought up to speed w/ master and based on your [PR #169](https://github.com/coreos/kube-aws/pull/169) and the direction from @mumoshu [#152 (comment)](https://github.com/coreos/kube-aws/issues/152#issuecomment-267197330).

---

Probably the biggest change to existing spec is it breaks away from the index based resource logical naming to a more predictable naming convention (e.g. `Subnet0` ->  `SubnetUsEast1a`). Doing so allows for one to allocate a NAT GW per AZ avoiding a single point of failure while downstream referencing the name by Region/AZ from the node pool workers by Stack/LogicalName (e.g. `cluster1-SubnetUsEast1aNatGateway`).

* An added benefit of moving away from index naming, changes to `cluster.yaml` `subnet`/`privateSubnet` list item order will not cause resources to be destroyed/created/reattached unnecessarily.

---

I'd be happy to collaborate more directly to see this make it in.

### TODO:

- [x] Evaluate option for a migration path for index based naming to AZ based naming (might be slim).
- [x] Node Pool yaml configuration for private worker subnets needs to be complete, should be mostly a copy of the etcd/controller configuration.
- [ ] Tests
